### PR TITLE
ci: fix DL3025 and allow DL3064 for user-supplied credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ghcr.io/sdr-enthusiasts/docker-baseimage:soapy-full
 
+# ICECAST_ADMIN_PASSWORD is a placeholder default that the user overrides with
+# their own Icecast admin password at run time. Supplying it via the environment
+# is inherent to how this image is configured, so DL3064 is not actionable here.
+# hadolint ignore=DL3064
 ENV BRANCH_RTLSDR="ed0317e6a58c098874ac58b769cf2e609c18d9a5" \
     S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     ## Both services

--- a/Dockerfile
+++ b/Dockerfile
@@ -283,4 +283,4 @@ RUN set -x && \
 ENTRYPOINT [ "/init" ]
 
 # Add healthcheck
-HEALTHCHECK --start-period=300s --interval=300s CMD /scripts/healthcheck.sh
+HEALTHCHECK --start-period=300s --interval=300s CMD ["/scripts/healthcheck.sh"]


### PR DESCRIPTION
## Problem

This repo has **two** findings from hadolint 2.15.x, both latent — `flake.lock` pins 2.14.0, and `check_docker` is already `true`, so the `Lint` job on every PR breaks the moment a lock bump lands 2.15.x.

```console
$ hadolint --config <shared ruleset> Dockerfile     # 2.14.0, the flake.lock pin
rc=0

$ hadolint --config <shared ruleset> Dockerfile     # 2.15.1
Dockerfile:3   DL3064 warning: Potentially sensitive data should not be used in the `ARG` or `ENV` commands
Dockerfile:282 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
rc=1
```

- **DL3025** — new `HEALTHCHECK` coverage from hadolint [#1209](https://github.com/hadolint/hadolint/pull/1209), shipped in v2.15.0 (published 2026-07-30T13:39:01Z). The rule itself is not new; only its application to `HEALTHCHECK` is.
- **DL3064** — a new rule in v2.15.0, flagging `ARG`/`ENV` assignments whose name suggests sensitive data.

There is no hadolint job in the deploy workflow here, so unlike some siblings in this series there was no risk to the deploy path — only to `Lint`.

## Changes

**`chore: allow DL3064 for the user-supplied Icecast admin password`**

```diff
+# ICECAST_ADMIN_PASSWORD is a placeholder default that the user overrides with
+# their own Icecast admin password at run time. Supplying it via the environment
+# is inherent to how this image is configured, so DL3064 is not actionable here.
+# hadolint ignore=DL3064
 ENV BRANCH_RTLSDR="..." \
```

`ICECAST_ADMIN_PASSWORD="rtlsdrairband"` is a placeholder the user overrides at run time. Supplying credentials through the environment is inherent to how this image is configured, so the finding is not actionable without a breaking change to the configuration interface.

Suppressed **inline** rather than adding `DL3064` to the shared ruleset, so the check stays active in every other repo. This matches the existing inline `SC2068` pragma already in this file, and the same decision taken in `docker-sdrmap#57`.

**`fix: use JSON exec form for HEALTHCHECK CMD`**

```diff
-HEALTHCHECK --start-period=300s --interval=300s CMD /scripts/healthcheck.sh
+HEALTHCHECK --start-period=300s --interval=300s CMD ["/scripts/healthcheck.sh"]
```

No `flake.nix` change was needed — `check_docker` is already `true` here.

## Verification

The `DL3064` pragma is correctly **scoped to one instruction** and does not blanket-suppress. An unrelated offending `RUN` after it still reports normally:

```console
FROM debian:trixie-slim
# hadolint ignore=DL3064
ENV ICECAST_ADMIN_PASSWORD="rtlsdrairband"
RUN apt-get update && apt-get install -y curl

-:4 DL3008 warning: Pin versions in apt get install...
-:4 DL3009 info: Delete the apt lists (/var/lib/apt/lists) after installing something
-:4 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
rc=1
```

For `DL3025`, the exec form drops the intervening `/bin/sh -c`, so the kernel must resolve the script's `#!/command/with-contenv bash` shebang itself — a symlink into the s6-overlay tree, not a normal interpreter path. Preconditions confirmed in the published image, then both forms run side by side under Docker's real healthcheck machinery — the **published image** (shell form) against a **local build of this branch** (exec form), with only the probe timing overridden:

```text
=== published / shell ===                    === rebuilt / exec ===
unhealthy                                    unhealthy
["CMD-SHELL","/scripts/healthcheck.sh"]      ["CMD","/scripts/healthcheck.sh"]
exit=1                                       exit=1
```

Byte-identical output on both sides:

```text
ICECAST CONNETIVITY CHECKS:
Checking icecast connection to 127.0.0.1:8000...
TCP4 connection between ANY:ANY and 127.0.0.1:8000 not established: FAIL
```

`unhealthy` is expected without a running Icecast server and SDR hardware; identical failure on both sides proves form-equivalence just as well as identical success would, and confirms exit codes still propagate in exec form.

Image config compared against the published image — only `Test[0]` differs:

```console
built    : {"Test":["CMD","/scripts/healthcheck.sh"],"Interval":300000000000,"StartPeriod":300000000000}
published: {"Test":["CMD-SHELL","/scripts/healthcheck.sh"],"Interval":300000000000,"StartPeriod":300000000000}
```

`Config.Entrypoint` is `["/init"]` on both, so s6 remains PID 1 and `docker stop` still reaches it for graceful shutdown.

Checked at each commit individually, so `git bisect` stays usable. Note the first commit is still `rc=1` at 2.15.1 because the second finding is fixed in the next commit; at the **pinned** 2.14.0 — the version actually enforced — both commits are clean:

```text
SHA       2.14.0  2.15.1  subject
7c4217a0  rc=0    rc=1    chore: allow DL3064 for the user-supplied Icecast admin password
def68cd8  rc=0    rc=0    fix: use JSON exec form for HEALTHCHECK CMD
```

Also checked:

- `nix develop -c pre-commit run --all-files`: green, all hooks Passed or Skipped
- `docker build --platform linux/amd64`: succeeds
- The `ENV` block precedes `SHELL`, so this Dockerfile is not exposed to the hadolint 2.15.x shell-tracking regression (`ARG`/`ENV` after `SHELL` resets the dialect to POSIX sh and spuriously reports `SC3xxx`)
- No hooks bypassed; no `--no-verify`
